### PR TITLE
[4/4] Update the Rack SDK to support ruby 3.x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,9 @@
 /db/*.sqlite3
 /db/*.sqlite3-journal
 
+# User-specific stuff:
+.idea/
+
 # Ignore all logfiles and tempfiles.
 /log/*
 /tmp/*

--- a/Gemfile
+++ b/Gemfile
@@ -3,4 +3,5 @@
 source "https://rubygems.org"
 
 gem 'rack'
-gem 'moesif_rack', '~> 1.4.10'
+gem 'moesif_rack', '~> 1.4.14'
+gem 'puma'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -59,4 +59,4 @@ DEPENDENCIES
   rack
 
 BUNDLED WITH
-   2.2.4
+   2.3.6

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,45 +1,52 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.7.0)
+    addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
     http-accept (1.7.0)
-    http-cookie (1.0.3)
+    http-cookie (1.0.4)
       domain_name (~> 0.5)
-    json (2.5.1)
-    json (2.5.1-java)
+    json (2.6.1)
+    json (2.6.1-java)
     json_mapper (0.2.1)
       json (>= 1.4.3)
-    mime-types (3.3.1)
+    mime-types (3.4.1)
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2021.0225)
-    moesif_api (1.2.12)
+    mime-types-data (3.2022.0105)
+    moesif_api (1.2.14)
       json_mapper (~> 0.2.1)
-      moesif_unirest (~> 1.1.5)
-      test-unit (~> 3.1.5)
-    moesif_rack (1.4.10)
-      moesif_api (~> 1.2, >= 1.2.12)
-    moesif_unirest (1.1.5)
-      addressable (>= 2.3.5)
+      moesif_unirest (~> 1.1.6)
+      test-unit (~> 3.5, >= 3.5.0)
+    moesif_rack (1.4.14)
+      addressable (~> 2.8.0)
+      moesif_api (~> 1.2, >= 1.2.14)
+    moesif_unirest (1.1.6)
+      addressable (~> 2.8.0)
       json (>= 1.8.1)
       rest-client (>= 1.8.0)
     netrc (0.11.0)
-    power_assert (2.0.0)
+    nio4r (2.5.8)
+    nio4r (2.5.8-java)
+    power_assert (2.0.1)
     public_suffix (4.0.6)
+    puma (5.6.1)
+      nio4r (~> 2.0)
+    puma (5.6.1-java)
+      nio4r (~> 2.0)
     rack (2.2.3)
     rest-client (2.1.0)
       http-accept (>= 1.7.0, < 2.0)
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
-    test-unit (3.1.9)
+    test-unit (3.5.3)
       power_assert
     unf (0.1.4)
       unf_ext
     unf (0.1.4-java)
-    unf_ext (0.0.7.7)
+    unf_ext (0.0.8)
 
 PLATFORMS
   java
@@ -47,7 +54,8 @@ PLATFORMS
   universal-java-1.8
 
 DEPENDENCIES
-  moesif_rack (~> 1.4.10)
+  moesif_rack (~> 1.4.14)
+  puma
   rack
 
 BUNDLED WITH


### PR DESCRIPTION
Ticket: https://www.pivotaltracker.com/n/projects/1646401/stories/181066034

Update the Rack SDK to support ruby 3.x
[1/4] https://github.com/Moesif/unirest-ruby/pull/4
[2/4] https://github.com/Moesif/moesifapi-ruby/pull/13
[3/4] https://github.com/Moesif/moesif-rack/pull/38
